### PR TITLE
Fixed German Trademark Notice

### DIFF
--- a/de/browser/branding/official/brand.ftl
+++ b/de/browser/branding/official/brand.ftl
@@ -36,4 +36,4 @@
 # remain unchanged across different versions (Nightly, Beta, etc.).
 -brand-product-name = Floorp
 -vendor-short-name = Ablaze
-trademarkInfo = Firefox und die Firefox-Logos sind Warenzeichen der Mozilla Foundation.
+trademarkInfo = Floorp und die Floorp-Logos sind Warenzeichen von Ablaze.

--- a/en-US/floorp.ftl
+++ b/en-US/floorp.ftl
@@ -91,7 +91,7 @@ hover-vertical-tab =
  .label = Collapse Vertical Tab Bar
 
 TST = Tree Style Tab
-about-TST = Tree Style Tab is a popular add-on that allows you to display tabs in a tree structure. { -brand-short-name } 10 has a built-in this add-on. Please install the add-on restore { -brand-short-name } 10's built-in Tree Style Tab.
+about-TST = Tree Style Tab is a popular add-on that allows you to display tabs in a tree-like structure. { -brand-short-name } 10 has this add-on built in. Please install the add-on to restore { -brand-short-name } 10's built-in Tree Style Tab.
 treestyletab-Settings = 
  .label = Collapse Tree Style Tab
 
@@ -797,16 +797,16 @@ status-bar =
 ##################################################################### Gesturefy ###############################################################
 
 gf-floorp-open-tree-style-tab-name = [{ -brand-short-name }] Open Tree Style Tab Panel
-gf-floorp-open-tree-style-tab-description = Open Tree Style Tab Panel of Sidebar
+gf-floorp-open-tree-style-tab-description = Open Tree Style Tab Panel on the Sidebar
 
-gf-floorp-open-bookmarks-sidebar-name = [{ -brand-short-name }] Open Bookmarks Panel of Sidebar
-gf-floorp-open-bookmarks-sidebar-description = Open Bookmarks Panel of Sidebar
+gf-floorp-open-bookmarks-sidebar-name = [{ -brand-short-name }] Open Bookmarks Panel
+gf-floorp-open-bookmarks-sidebar-description = Open Bookmarks Panel on the Sidebar
 
-gf-floorp-open-history-sidebar-name = [{ -brand-short-name }] Open History Panel of Sidebar
-gf-floorp-open-history-sidebar-description = Open History Panel of Sidebar
+gf-floorp-open-history-sidebar-name = [{ -brand-short-name }] Open History Panel
+gf-floorp-open-history-sidebar-description = Open History Panel on the Sidebar
 
-gf-floorp-open-synctabs-sidebar-name = [{ -brand-short-name }] Open Synced Tabs Panel of Sidebar
-gf-floorp-open-synctabs-sidebar-description = Open Synced Tabs Panel of Sidebar
+gf-floorp-open-synctabs-sidebar-name = [{ -brand-short-name }] Open Synced Tabs Panel
+gf-floorp-open-synctabs-sidebar-description = Open Synced Tabs Panel on the Sidebar
 
 gf-floorp-close-sidebar-name = [{ -brand-short-name }] Close Sidebar
 gf-floorp-close-sidebar-description = Close Sidebar
@@ -827,8 +827,8 @@ gf-floorp-hide-statusbar-description = Hide Status Bar
 gf-floorp-show-statusbar-name = [{ -brand-short-name }] Toggle Status Bar
 gf-floorp-show-statusbar-description = Show or Hide Status Bar
 
-gf-floorp-open-extension-sidebar-name = [{ -brand-short-name }] Open selected add-on of Sidebar
-gf-floorp-open-extension-sidebar-description = Open selected add-on of Sidebar
+gf-floorp-open-extension-sidebar-name = [{ -brand-short-name }] Open selected add-on Sidebar
+gf-floorp-open-extension-sidebar-description = Open selected add-on on the Sidebar
 gf-floorp-open-extension-sidebar-settings-addons-id = Add-on of Sidebar
 gf-floorp-open-extension-sidebar-settings-addons-id-description = The extension of the add-on open of sidebar
 gf-floorp-open-extension-sidebar-settings-list-default = Please select add-on


### PR DESCRIPTION
Have noticed that on a german install of Floorp that the about box still identifies Floorp as Firefox as seen in the attached screenshot.

![image](https://github.com/Floorp-Projects/Unified-l10n-central/assets/94994630/6913d802-b0c3-4c71-9598-92d037638097)
