### PR TITLE
Restored the Floorp branding notice in British Floorp

### DIFF
--- a/en-GB/browser/branding/official/brand.ftl
+++ b/en-GB/browser/branding/official/brand.ftl
@@ -36,4 +36,4 @@
 # remain unchanged across different versions (Nightly, Beta, etc.).
 -brand-product-name = Floorp
 -vendor-short-name = Ablaze
-trademarkInfo = Firefox and the Firefox logos are trademarks of the Mozilla Foundation.
+trademarkInfo = Floorp and the Floorp logos are trademarks of Ablaze.


### PR DESCRIPTION
A regression reverted it to Firefox's string.