### PR TITLE
Align ja-JP-mac branding with ja-JP

### DIFF
--- a/ja-JP-mac/toolkit/toolkit/branding/brandings.ftl
+++ b/ja-JP-mac/toolkit/toolkit/branding/brandings.ftl
@@ -21,20 +21,20 @@
 -monitor-brand-short-name = Monitor
 -pocket-brand-name = Pocket
 -send-brand-name = Firefox Send
--screenshots-brand-name = Firefox Screenshots
+-screenshots-brand-name = Floorp Screenshots
 -mozilla-vpn-brand-name = Mozilla VPN
 -profiler-brand-name = Firefox Profiler
--translations-brand-name = Firefox Translations
+-translations-brand-name = Floorp Translations
 -focus-brand-name = Firefox Focus
 -relay-brand-name = Firefox Relay
 -relay-brand-short-name = Relay
 -fakespot-brand-name = Fakespot
 # “Suggest” can be localized, “Firefox” must be treated as a brand
 # and kept in English.
--firefox-suggest-brand-name = Firefox Suggest
+-firefox-suggest-brand-name = Floorp Suggest
 # ”Home" can be localized, “Firefox” must be treated as a brand
 # and kept in English.
--firefox-home-brand-name = Firefox Home
+-firefox-home-brand-name = Floorp Home
 # View" can be localized, “Firefox” must be treated as a brand
 # and kept in English.
--firefoxview-brand-name = Firefox View
+-firefoxview-brand-name = Floorp View


### PR DESCRIPTION
[ja-JP-mac/toolkit/toolkit/branding/brandings.ftl](https://github.com/Floorp-Projects/Unified-l10n-central/blob/main/ja-JP-mac/toolkit/toolkit/branding/brandings.ftl) の ブランド名を ja と合わせました。