### PR TITLE
replaced pocket string in homepage settings

### DIFF
--- a/de/browser/browser/preferences/preferences.ftl
+++ b/de/browser/browser/preferences/preferences.ftl
@@ -568,7 +568,7 @@ home-prefs-shortcuts-by-option-sponsored =
 
 home-prefs-recommended-by-header =
     .label = Empfohlen von { $provider }
-home-prefs-recommended-by-description-new = Besondere Inhalte ausgewählt von { $provider }, Teil der { -brand-product-name }-Familie
+home-prefs-recommended-by-description-new = Besondere Inhalte ausgewählt von { $provider }, Teil der Firefox-Familie
 
 ##
 


### PR DESCRIPTION
noticed that one while looking though floorp daylight's settings
again, is pocket related

![grafik](https://github.com/Floorp-Projects/Unified-l10n-central/assets/94994630/c4fa6804-9238-4911-b71c-6963e1ae27f8)
