### PR TITLE
Correction of french translation aberrations from mozilla

### DIFF
--- a/fr/browser/browser/accounts.ftl
+++ b/fr/browser/browser/accounts.ftl
@@ -51,7 +51,7 @@ account-connection-connected-with = Cet ordinateur est maintenant synchronisé a
 # Used when the name of the new device is not known.
 account-connection-connected-with-noname = Cet ordinateur est maintenant synchronisé avec un nouvel appareil.
 # Used in a notification shown after a Firefox account is connected to the current device.
-account-connection-connected = Vous vous êtes connecté·e avec succès
+account-connection-connected = Vous vous êtes connecté avec succès
 # Used in a notification shown after the Firefox account was disconnected remotely.
 account-connection-disconnected = Cet ordinateur a été correctement déconnecté.
 

--- a/fr/browser/browser/newtab/asrouter.ftl
+++ b/fr/browser/browser/newtab/asrouter.ftl
@@ -68,7 +68,7 @@ cfr-doorhanger-bookmark-fxa-close-btn-tooltip =
 
 ## Protections panel
 
-cfr-protections-panel-header = Naviguez sans être suivi·e
+cfr-protections-panel-header = Naviguez sans être suivi
 cfr-protections-panel-body = Gardez vos données pour vous. { -brand-short-name } vous protège de la plupart des traqueurs les plus courants qui suivent ce que vous faites en ligne.
 cfr-protections-panel-link-text = En savoir plus
 

--- a/fr/browser/browser/preferences/fxaPairDevice.ftl
+++ b/fr/browser/browser/preferences/fxaPairDevice.ftl
@@ -17,6 +17,6 @@ fxa-qrcode-pair-title = Synchronisez { -brand-product-name } avec votre téléph
 fxa-qrcode-pair-step1 = 1. Ouvrez { -brand-product-name } sur votre appareil mobile
 fxa-qrcode-pair-step2 = 2. Ouvrez le <strong>menu</strong> (<img data-l10n-name="ios-menu-icon"/> sous iOS ou <img data-l10n-name="android-menu-icon"/> sous Android) et appuyez sur <strong>Se connecter pour synchroniser</strong>
 fxa-qrcode-pair-step2-signin = 2. Ouvrez le menu (<img data-l10n-name="ios-menu-icon"/> sous iOS ou <img data-l10n-name="android-menu-icon"/> sous Android) et appuyez sur <strong>Synchroniser et enregistrer les données</strong>
-fxa-qrcode-pair-step3 = 3. Appuyez sur <strong>Prêt·e à scanner</strong> et maintenez votre appareil au-dessus de ce code
+fxa-qrcode-pair-step3 = 3. Appuyez sur <strong>Prêt à scanner</strong> et maintenez votre appareil au-dessus de ce code
 fxa-qrcode-error-title = Échec de l’association.
 fxa-qrcode-error-body = Veuillez réessayer.

--- a/fr/browser/browser/preferences/preferences.ftl
+++ b/fr/browser/browser/preferences/preferences.ftl
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-do-not-track-description = Envoyer aux sites web un signal « Ne pas me pister » indiquant que vous ne souhaitez pas être pisté·e
+do-not-track-description = Envoyer aux sites web un signal « Ne pas me pister » indiquant que vous ne souhaitez pas être pisté
 do-not-track-learn-more = En savoir plus
 do-not-track-option-default-content-blocking-known =
     .label = Seulement quand { -brand-short-name } est paramétré pour bloquer les traqueurs connus

--- a/fr/browser/browser/sync.ftl
+++ b/fr/browser/browser/sync.ftl
@@ -29,6 +29,6 @@ fxa-menu-send-tab-to-device =
 fxa-menu-send-tab-to-device-syncnotready =
     .label = Synchronisation des appareils…
 # This is shown within "Send tab to device" in fxa menu if account is not configured.
-fxa-menu-send-tab-to-device-description = Envoyez instantanément un onglet sur n’importe quel appareil où vous êtes connecté·e.
+fxa-menu-send-tab-to-device-description = Envoyez instantanément un onglet sur n’importe quel appareil où vous êtes connecté.
 fxa-menu-sign-out =
     .label = Se déconnecter…

--- a/fr/browser/chrome/browser/accounts.properties
+++ b/fr/browser/chrome/browser/accounts.properties
@@ -31,7 +31,7 @@ otherDeviceConnectedBody.noDeviceName = Cet ordinateur est maintenant synchronis
 
 # LOCALIZATION NOTE (thisDeviceConnectedBody) - used in a notification shown
 # after a Firefox Account is connected to the current device.
-thisDeviceConnectedBody = Vous vous êtes connecté·e avec succès
+thisDeviceConnectedBody = Vous vous êtes connecté avec succès
 
 # LOCALIZATION NOTE (thisDeviceDisconnectedBody) - used in a notification shown
 # after the Firefox Account was disconnected remotely.
@@ -48,7 +48,7 @@ manageDevices.menuitem = Gérer les appareils…
 # LOCALIZATION NOTE (sendTabToDevice.unconfigured, sendTabToDevice.unconfigured.label2)
 # Displayed in the Send Tabs context menu when right clicking a tab, a page or a link
 # and the Sync account is unconfigured. Redirects to a marketing page.
-sendTabToDevice.unconfigured.label2 = Vous n’êtes pas connecté·e
+sendTabToDevice.unconfigured.label2 = Vous n’êtes pas connecté
 sendTabToDevice.unconfigured = En savoir plus sur l’envoi d’onglets…
 
 # LOCALIZATION NOTE (sendTabToDevice.signintofxa)


### PR DESCRIPTION
French mistakes have been included for ideological reasons by mozilla's French translation team and do not represent the reality of spelling and language. It's to correct these aberrations that I'm posting this pull request.